### PR TITLE
fix: handle URLs in mrkdwn format

### DIFF
--- a/server/tests/slackUtils.test.js
+++ b/server/tests/slackUtils.test.js
@@ -7,59 +7,84 @@ describe('slackUtils.js', () => {
     const expected = 'adobe.com';
 
     assert.strictEqual(extractDomainFromInput('get site adobe.com', false), expected);
+    assert.strictEqual(extractDomainFromInput('get site <adobe.com|www.adobe.com>', false), expected);
     assert.strictEqual(extractDomainFromInput('get site adobe.com/', false), expected);
+    assert.strictEqual(extractDomainFromInput('get site <adobe.com/>', false), expected);
     assert.strictEqual(extractDomainFromInput('get site http://adobe.com', false), expected);
+    assert.strictEqual(extractDomainFromInput('get site <http://adobe.com|www.adobe.com>', false), expected);
     assert.strictEqual(extractDomainFromInput('get site https://adobe.com', false), expected);
+    assert.strictEqual(extractDomainFromInput('get site <https://adobe.com|www.adobe.com>', false), expected);
     assert.strictEqual(extractDomainFromInput('get site https://www.adobe.com', false), expected);
+    assert.strictEqual(extractDomainFromInput('get site <https://www.adobe.com|www.adobe.com>', false), expected);
     assert.strictEqual(extractDomainFromInput('get site https://www.adobe.com/', false), expected);
+    assert.strictEqual(extractDomainFromInput('get site <https://www.adobe.com/>', false), expected);
   });
 
   it('extractDomainFromInput with path', async () => {
     const expected = 'adobe.com/some/path/w1th_numb3rs';
 
     assert.strictEqual(extractDomainFromInput('add site http://adobe.com/some/path/w1th_numb3rs', false), expected);
+    assert.strictEqual(extractDomainFromInput('add site <http://adobe.com/some/path/w1th_numb3rs|adobe.com/some/path/w1th_numb3rs>', false), expected);
     assert.strictEqual(extractDomainFromInput('add site https://adobe.com/some/path/w1th_numb3rs', false), expected);
+    assert.strictEqual(extractDomainFromInput('add site <https://adobe.com/some/path/w1th_numb3rs|adobe.com/some/path/w1th_numb3rs>', false), expected);
     assert.strictEqual(extractDomainFromInput('add site https://www.adobe.com/some/path/w1th_numb3rs', false), expected);
+    assert.strictEqual(extractDomainFromInput('add site <https://www.adobe.com/some/path/w1th_numb3rs|www.adobe.com/some/path/w1th_numb3rs>', false), expected);
     assert.strictEqual(extractDomainFromInput('add site https://www.adobe.com/some/path/w1th_numb3rs/', false), expected + '/');
+    assert.strictEqual(extractDomainFromInput('add site <https://www.adobe.com/some/path/w1th_numb3rs/>', false), expected + '/');
   });
 
   it('extractDomainFromInput with subdomain and path', async () => {
     const expected = 'business.adobe.com/some/path/w1th_numb3rs';
 
     assert.strictEqual(extractDomainFromInput('get site http://business.adobe.com/some/path/w1th_numb3rs', false), expected);
+    assert.strictEqual(extractDomainFromInput('get site <http://business.adobe.com/some/path/w1th_numb3rs|business.adobe.com/some/path/w1th_numb3rs>', false), expected);
     assert.strictEqual(extractDomainFromInput('get site https://business.adobe.com/some/path/w1th_numb3rs', false), expected);
+    assert.strictEqual(extractDomainFromInput('get site <https://business.adobe.com/some/path/w1th_numb3rs|business.adobe.com/some/path/w1th_numb3rs>', false), expected);
     assert.strictEqual(extractDomainFromInput('add site https://business.adobe.com/some/path/w1th_numb3rs/', false), expected + '/');
+    assert.strictEqual(extractDomainFromInput('add site <https://business.adobe.com/some/path/w1th_numb3rs/>', false), expected + '/');
   });
 
   it('extractDomainFromInput with subdomain, path and extension', async () => {
     const expected = 'personal.nedbank.co.za/borrow/personal-loans.html';
 
     assert.strictEqual(extractDomainFromInput('get site personal.nedbank.co.za/borrow/personal-loans.html', false), expected);
+    assert.strictEqual(extractDomainFromInput('get site <personal.nedbank.co.za/borrow/personal-loans.html|personal.nedbank.co.za/borrow/personal-loans.html>', false), expected);
     assert.strictEqual(extractDomainFromInput('get site https://personal.nedbank.co.za/borrow/personal-loans.html', false), expected);
+    assert.strictEqual(extractDomainFromInput('get site <https://personal.nedbank.co.za/borrow/personal-loans.html|personal.nedbank.co.za/borrow/personal-loans.html>', false), expected);
     assert.strictEqual(extractDomainFromInput('get site https://personal.nedbank.co.za/borrow/personal-loans.html/', false), expected);
+    assert.strictEqual(extractDomainFromInput('get site <https://personal.nedbank.co.za/borrow/personal-loans.html/>', false), expected);
   });
 
   it('extractDomainFromInput with subdomain, path, selector and extension', async () => {
     const expected = 'personal.nedbank.co.za/borrow/personal-loans.plain.html';
 
     assert.strictEqual(extractDomainFromInput('get site personal.nedbank.co.za/borrow/personal-loans.plain.html', false), expected);
+    assert.strictEqual(extractDomainFromInput('get site <personal.nedbank.co.za/borrow/personal-loans.plain.html|personal.nedbank.co.za/borrow/personal-loans.plain.html>', false), expected);
     assert.strictEqual(extractDomainFromInput('get site https://personal.nedbank.co.za/borrow/personal-loans.plain.html', false), expected);
+    assert.strictEqual(extractDomainFromInput('get site <https://personal.nedbank.co.za/borrow/personal-loans.plain.html|personal.nedbank.co.za/borrow/personal-loans.plain.html>', false), expected);
     assert.strictEqual(extractDomainFromInput('get site https://personal.nedbank.co.za/borrow/personal-loans.plain.html/', false), expected);
+    assert.strictEqual(extractDomainFromInput('get site <https://personal.nedbank.co.za/borrow/personal-loans.plain.html/>', false), expected);
   });
 
   it('extractDomainFromInput domain only', async () => {
     const expected = 'business.adobe.com';
 
     assert.strictEqual(extractDomainFromInput('get site http://business.adobe.com/some/path/w1th_numb3rs'), expected);
+    assert.strictEqual(extractDomainFromInput('get site <http://business.adobe.com/some/path/w1th_numb3rs|business.adobe.com/some/path/w1th_numb3rs>'), expected);
     assert.strictEqual(extractDomainFromInput('get site https://business.adobe.com/some/path/w1th_numb3rs'), expected);
+    assert.strictEqual(extractDomainFromInput('get site <https://business.adobe.com/some/path/w1th_numb3rs|business.adobe.com/some/path/w1th_numb3rs>'), expected);
     assert.strictEqual(extractDomainFromInput('add site https://business.adobe.com/some/path/w1th_numb3rs/'), expected);
+    assert.strictEqual(extractDomainFromInput('add site <https://business.adobe.com/some/path/w1th_numb3rs/>'), expected);
   });
 
   it('extractDomainFromInput with trailing tokens', async () => {
     const expected = 'personal.nedbank.co.za/borrow/personal-loans.plain.html';
 
     assert.strictEqual(extractDomainFromInput('get site personal.nedbank.co.za/borrow/personal-loans.plain.html test', false), expected);
+    assert.strictEqual(extractDomainFromInput('get site <personal.nedbank.co.za/borrow/personal-loans.plain.html|personal.nedbank.co.za/borrow/personal-loans.plain.html> test', false), expected);
     assert.strictEqual(extractDomainFromInput('get site https://personal.nedbank.co.za/borrow/personal-loans.plain.html www.acme.com', false), expected);
+    assert.strictEqual(extractDomainFromInput('get site <https://personal.nedbank.co.za/borrow/personal-loans.plain.html|personal.nedbank.co.za/borrow/personal-loans.plain.html> www.acme.com', false), expected);
     assert.strictEqual(extractDomainFromInput('get site https://personal.nedbank.co.za/borrow/personal-loans.plain.html/ extra acme.com/', false), expected);
+    assert.strictEqual(extractDomainFromInput('get site <https://personal.nedbank.co.za/borrow/personal-loans.plain.html/> extra acme.com/ <acme.com/> <http://acme.com|acme.com>', false), expected);
   });
 });

--- a/server/utils/slackUtils.js
+++ b/server/utils/slackUtils.js
@@ -16,7 +16,11 @@ function extractDomainFromInput(input, domainOnly = true) {
 
   for (const token of tokens) {
     if ((match = SLACK_URL_FORMAT_REGEX.exec(token)) !== null) {
-      const urlToken = token.includes('://') ? token : `http://${token}`;
+      // see https://api.slack.com/reference/surfaces/formatting#links-in-retrieved-messages
+      const processedToken = token.charAt(0) === '<' && token.charAt(token.length - 1) === '>'
+        ? token.slice(1, token.length - 1).split('|').at(0)
+        : token;
+      const urlToken = processedToken.includes('://') ? processedToken : `http://${processedToken}`;
       const url = new URL(urlToken);
       const { hostname, pathname } = url;
       // we do not keep the www


### PR DESCRIPTION
Extracts domain + path from plain URLs as well as URLs in mrkdwn format.

Before:

<http://acme.com/> and <http://acme.com|acme.com> would fail.

After:

http://acme.com/, http://acme.com, <http://acme.com/> and <http://acme.com|acme.com> get successfully parsed with domain + path properly extracted.